### PR TITLE
fix: Note CC BY 4.0 license

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -96,7 +96,7 @@ foothr = true # show or hide horizontal rule above footer
 ### $CURRENT_YEAR and $SITE_TITLE can be used anywhere within the copyright, you can change their position or you can also delete them and type whatever you want instead.
 copyright = true # set to false to disable the copyright.
 #copyright_override = '© 2019-$CURRENT_YEAR $SITE_TITLE'
-#copyright_override = '© $CURRENT_YEAR $SITE_TITLE • Website content is licensed <a rel="noopener" target="_blank" href="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>.'
+copyright_override = '© $CURRENT_YEAR $SITE_TITLE • Website content is licensed <a rel="noopener" target="_blank" href="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>.'
 
 
 ###############################################################################


### PR DESCRIPTION
I'd noted this in the repo's README, but I worried that the dry copyright notice in the footer was misleading.

Hopefully this change makes clear: do with this content what you want, as long as you cite me.