### PR TITLE
fix: We've moved to a proper domain!

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
 # do NOT include a trailing slash on the base URL
-base_url = "https://averagehelper.github.io"
+base_url = "https://blog.average.name"
 # Usable site directly from disk, Including Search: "/home/jieiku/.dev/abridge/public"
 # Also set index_format = "elasticlunr_javascript", and in [extra] uglyurls = true, integrity = false
 # If you use the npm/node script then all you have to do is set offline = true, and everything else is automatic.
@@ -176,7 +176,7 @@ codeberg = "AverageHelper" # Everything after https://codeberg.org/   eg: userna
 ###############################################################################
 
 # do NOT include a trailing slash on the online URL
-online_url="https://averagehelper.github.io"
+online_url="https://blog.average.name"
 offline = false # implies uglyurls=true and integrity=false, when true NPM/node will automatically set the path for the base_url, it will build the site, then set the base_url back to what it was.
 
 uglyurls = false # if set to true then links are generated with the full path. eg https://abridge.netlify.app/index.html


### PR DESCRIPTION
Replaced referenced to "averagehelper.github.io" with "blog.average.name"